### PR TITLE
Fixed quick replies

### DIFF
--- a/fbmessenger/attachments.py
+++ b/fbmessenger/attachments.py
@@ -33,7 +33,7 @@ class BaseAttachment(object):
             d['attachment']['payload']['attachment_id'] = self.attachment_id
 
         if self.quick_replies:
-            d['attachment']['quick_replies'] = self.quick_replies.to_dict()
+            d['quick_replies'] = self.quick_replies.to_dict()
 
         return d
 

--- a/fbmessenger/templates.py
+++ b/fbmessenger/templates.py
@@ -27,7 +27,7 @@ class BaseTemplate(object):
 
     def to_dict(self):
         if self.quick_replies:
-            self._d['attachment']['quick_replies'] = self.quick_replies.to_dict()
+            self._d['quick_replies'] = self.quick_replies.to_dict()
 
         return self._d
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -68,19 +68,19 @@ class TestAttachments:
                 'payload': {
                     'url': 'http://facebook.com/image.jpg'
                 },
-                'quick_replies': [
-                    {
-                        'content_type': 'text',
-                        'title': 'QR',
-                        'payload': 'QR payload'
-                    },
-                    {
-                        'content_type': 'text',
-                        'title': 'QR',
-                        'payload': 'QR payload'
-                    }
-                ]
-            }
+            },
+            'quick_replies': [
+                {
+                    'content_type': 'text',
+                    'title': 'QR',
+                    'payload': 'QR payload'
+                },
+                {
+                    'content_type': 'text',
+                    'title': 'QR',
+                    'payload': 'QR payload'
+                },
+            ],
         }
         assert expected == res.to_dict()
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -198,19 +198,19 @@ class TestTemplates:
                         }
                     ],
                 },
-                'quick_replies': [
-                    {
-                        'content_type': 'text',
-                        'title': 'QR',
-                        'payload': 'QR payload'
-                    },
-                    {
-                        'content_type': 'text',
-                        'title': 'QR',
-                        'payload': 'QR payload'
-                    }
-                ]
-            }
+            },
+            'quick_replies': [
+                {
+                    'content_type': 'text',
+                    'title': 'QR',
+                    'payload': 'QR payload'
+                },
+                {
+                    'content_type': 'text',
+                    'title': 'QR',
+                    'payload': 'QR payload'
+                },
+            ],
         }
         assert expected == res.to_dict()
 


### PR DESCRIPTION
Quick replies are not part of the attachment (per Facebook api).