### PR TITLE
Log a warning message when some message strings are too long.

### DIFF
--- a/fbmessenger/elements.py
+++ b/fbmessenger/elements.py
@@ -1,3 +1,12 @@
+from __future__ import absolute_import
+
+import logging
+
+from .error_messages import CHARACTER_LIMIT_MESSAGE
+
+logger = logging.getLogger(__name__)
+
+
 class Text(object):
     def __init__(self, text, quick_replies=None):
         self.text = text
@@ -39,7 +48,8 @@ class Button(object):
         if webview_height_ratio and webview_height_ratio not in self.WEBVIEW_HEIGHT_RATIOS:
             raise ValueError('Invalid webview_height_ratio provided.')
         if title and len(title) > 20:
-            raise ValueError('Title cannot be longer 20 characters.')
+            logger.warning(CHARACTER_LIMIT_MESSAGE.format(field='Title',
+                                                          maxsize=20))
 
         self.button_type = button_type
         self.title = title
@@ -95,9 +105,8 @@ class Element(object):
     @title.setter
     def title(self, title):
         if len(title) > 80:
-            raise ValueError(
-                'Title cannot be longer 80 characters'
-            )
+            logger.warning(CHARACTER_LIMIT_MESSAGE.format(field='Title',
+                                                          maxsize=80))
         self._title = title
 
     @property
@@ -107,7 +116,8 @@ class Element(object):
     @subtitle.setter
     def subtitle(self, subtitle):
         if subtitle is not None and len(subtitle) > 80:
-            raise ValueError('Subtitle cannot be longer 80 characters')
+            logger.warning(CHARACTER_LIMIT_MESSAGE.format(field='Subtitle',
+                                                          maxsize=80))
         self._subtitle = subtitle
 
     def to_dict(self):

--- a/fbmessenger/error_messages.py
+++ b/fbmessenger/error_messages.py
@@ -1,0 +1,2 @@
+CHARACTER_LIMIT_MESSAGE = ("{field} is longer than {maxsize} characters, "
+                           "it will be truncated when displayed.")

--- a/fbmessenger/quick_replies.py
+++ b/fbmessenger/quick_replies.py
@@ -1,3 +1,12 @@
+from __future__ import absolute_import
+
+import logging
+
+from .error_messages import CHARACTER_LIMIT_MESSAGE
+
+logger = logging.getLogger(__name__)
+
+
 class QuickReply(object):
 
     CONTENT_TYPES = [
@@ -12,7 +21,8 @@ class QuickReply(object):
         if content_type not in self.CONTENT_TYPES:
             raise ValueError('Invalid content_type provided.')
         if title and len(title) > 20:
-            raise ValueError('Title cannot be longer 20 characters.')
+            logger.warning(CHARACTER_LIMIT_MESSAGE.format(field='Title',
+                                                          maxsize=20))
         if payload and len(payload) > 1000:
             raise ValueError('Payload cannot be longer 1000 characters.')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pbr==1.9.1
 py==1.4.31
 pyandoc==0.2.0
 pytest==2.8.7
+pytest-catchlog==1.2.2
 pytest-cov==2.2.1
 requests==2.10.0
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ test_requirements = [
     'pytest',
     'coverage',
     'pytest-cov',
+    'pytest-catchlog',
     'responses'
 ]
 

--- a/tests/test_quick_replies.py
+++ b/tests/test_quick_replies.py
@@ -1,6 +1,9 @@
+import logging
+
 import pytest
 
 from fbmessenger import quick_replies
+from fbmessenger.error_messages import CHARACTER_LIMIT_MESSAGE
 
 
 class TestQuickReplies:
@@ -19,11 +22,13 @@ class TestQuickReplies:
         }
         assert expected == res.to_dict()
 
-    def test_quick_reply_title_too_long(self):
-        with pytest.raises(ValueError) as err:
+    def test_quick_reply_title_too_long(self, caplog):
+        with caplog.at_level(logging.WARNING, logger='fbmessenger.elements'):
             quick_replies.QuickReply(title='Title is over the 20 character limit',
                                            payload='QR payload')
-        assert str(err.value) == 'Title cannot be longer 20 characters.'
+            assert caplog.record_tuples == [
+                ('fbmessenger.quick_replies', logging.WARNING,
+                  CHARACTER_LIMIT_MESSAGE.format(field='Title', maxsize=20))]
 
     def test_quick_reply_payload_too_long(self):
         payload = 'x' * 1001


### PR DESCRIPTION
Some title and subtitle fields can be longer than the soft limit given in the
documentation. They will be truncated when displayed on Messenger, and the Send
API does not raise any error.