### PR TITLE
Bring PersistentMenuItem up-to-date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ target/
 venv/
 ENV/
 
+# IntelliJ IDEA
+.idea
+*.iml

--- a/fbmessenger/thread_settings.py
+++ b/fbmessenger/thread_settings.py
@@ -31,7 +31,9 @@ class PersistentMenuItem(object):
         'postback'
     ]
 
-    def __init__(self, item_type, title, nested_items=None, url=None, payload=None):
+    def __init__(self, item_type, title, nested_items=None, url=None,
+                 payload=None, fallback_url=None, messenger_extensions=None,
+                 webview_share_button=None):
         if item_type not in self.ITEM_TYPES:
             raise ValueError('Invalid item_type provided.')
         if len(title) > 30:
@@ -43,8 +45,15 @@ class PersistentMenuItem(object):
                 raise ValueError('`nested_items` must be supplied for `nested` type menu items.')
             if len(nested_items) > 5:
                 raise ValueError('Cannot have more than 5 nested_items')
-        if item_type == 'web_url' and url is None:
-            raise ValueError('`url` must be supplied for `web_url` type menu items.')
+        if item_type == 'web_url':
+            if url is None:
+                raise ValueError('`url` must be supplied for `web_url` type menu items.')
+        else:
+            if messenger_extensions is not None:
+                raise ValueError('`messenger_extensions` is only valid for item type `web_url`')
+            if webview_share_button is not None:
+                raise ValueError('`webview_share_button` is only valid for item type `web_url`')
+
         if item_type == 'postback' and payload is None:
             raise ValueError('`payload` must be supplied for `postback` type menu items.')
 
@@ -52,6 +61,9 @@ class PersistentMenuItem(object):
         self.title = title
         self.nested_items = nested_items
         self.url = url
+        self.fallback_url = fallback_url
+        self.messenger_extensions = messenger_extensions
+        self.webview_share_button = webview_share_button
         self.payload = payload
 
     def to_dict(self):
@@ -63,8 +75,15 @@ class PersistentMenuItem(object):
         if self.nested_items and self.item_type == 'nested':
             res['call_to_actions'] = [item.to_dict() for item in self.nested_items]
 
-        if self.url and self.item_type == 'web_url':
-            res['url'] = self.url
+        if self.item_type == 'web_url':
+            if self.url:
+                res['url'] = self.url
+            if self.fallback_url:
+                res['fallback_url'] = self.fallback_url
+            if self.messenger_extensions is not None:
+                res['messenger_extensions'] = self.messenger_extensions
+            if self.webview_share_button is False:
+                res['webview_share_button'] = 'hide'
 
         if self.payload and self.item_type == 'postback':
             res['payload'] = self.payload

--- a/tests/test_thread_settings.py
+++ b/tests/test_thread_settings.py
@@ -39,6 +39,88 @@ class TestThreadSettings:
         }
         assert expected == res.to_dict()
 
+    def test_persistent_menu_item_web_url_fallback(self):
+        res = thread_settings.PersistentMenuItem(
+            item_type='web_url',
+            title='Link',
+            url='https://facebook.com',
+            fallback_url='https://facebook.com/fallback'
+        )
+        expected = {
+            'type': 'web_url',
+            'title': 'Link',
+            'url': 'https://facebook.com',
+            'fallback_url': 'https://facebook.com/fallback',
+        }
+        assert expected == res.to_dict()
+
+    def test_persistent_menu_messenger_extensions(self):
+        res = thread_settings.PersistentMenuItem(
+            item_type='web_url',
+            title='Link',
+            payload='payload',
+            url='https://facebook.com',
+            messenger_extensions=True
+        )
+        expected = {
+            'type': 'web_url',
+            'title': 'Link',
+            'url': 'https://facebook.com',
+            'messenger_extensions': True
+        }
+        assert expected == res.to_dict()
+
+    def test_persistent_menu_messenger_extensions_invalid(self):
+        with pytest.raises(ValueError) as err:
+            thread_settings.PersistentMenuItem(
+                item_type='postback',
+                title='Link',
+                payload='payload',
+                messenger_extensions=True
+            )
+        assert str(err.value) == '`messenger_extensions` is only valid for item type `web_url`'
+
+    def test_webview_share_button_invalid(self):
+        with pytest.raises(ValueError) as err:
+            thread_settings.PersistentMenuItem(
+                item_type='postback',
+                title='Link',
+                payload='payload',
+                webview_share_button=False
+            )
+        assert str(err.value) == '`webview_share_button` is only valid for item type `web_url`'
+
+    def test_webview_share_button_true(self):
+        res = thread_settings.PersistentMenuItem(
+            item_type='web_url',
+            title='Link',
+            payload='payload',
+            url='https://facebook.com',
+            webview_share_button=True
+        )
+        expected = {
+            'type': 'web_url',
+            'title': 'Link',
+            'url': 'https://facebook.com',
+        }
+        assert expected == res.to_dict()
+
+    def test_webview_share_button_false(self):
+        res = thread_settings.PersistentMenuItem(
+            item_type='web_url',
+            title='Link',
+            payload='payload',
+            url='https://facebook.com',
+            webview_share_button=False
+        )
+        expected = {
+            'type': 'web_url',
+            'title': 'Link',
+            'url': 'https://facebook.com',
+            'webview_share_button': 'hide'
+        }
+        assert expected == res.to_dict()
+
     def test_persistent_menu_item_postback(self):
         res = thread_settings.PersistentMenuItem(
             item_type='postback',


### PR DESCRIPTION
Specifically, this adds support for:
- fallback_url
- messenger_extensions
- webview_share_button

We also add some ignores for IntelliJ IDEA.