### PR TITLE
Support for media templates and attachment uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ ENV/
 # IntelliJ IDEA
 .idea
 *.iml
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ messenger.send(btn.to_dict())
 <a name="attachments"></a>
 ## Attachments
 
+You can upload attachments to Facebook for use in their other APIs:
+
+```python
+attachment = attachments.Image(url='https://example.com/image.jpg')
+client = MessengerClient(page_access_token=12345678)
+res = client.upload_attachment(attachment)
+print(res)
+{"attachment_id": "12345"}
+```
+
 ### Images
 
 ```python
@@ -255,6 +265,18 @@ res = templates.ReceiptTemplate(
     adjustments=[adjustment1, adjustment2],
     elements=[element]
 )
+messenger.send(res.to_dict())
+```
+
+### Media template
+```
+btn = elements.Button(
+    button_type='web_url',
+    title='Web button',
+    url='http://facebook.com'
+)
+attachment = attachments.Image(attachment_id='12345')
+res = templates.MediaTemplate(attachment, buttons=[btn])
 messenger.send(res.to_dict())
 ```
 

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -153,6 +153,22 @@ class MessengerClient(object):
         )
         return r.json()
 
+    def upload_attachment(self, attachment):
+        if not attachment.url:
+            raise ValueError('Attachment must have `url` specified')
+        if attachment.quick_replies:
+            raise ValueError('Attachment may not have `quick_replies`')
+        r = self.session.post(
+            'https://graph.facebook.com/v2.11/me/message_attachments',
+            params={
+                'access_token': self.page_access_token
+            },
+            json={
+                'message':  attachment.to_dict()
+            }
+        )
+        return r.json()
+
 
 class BaseMessenger(object):
     __metaclass__ = abc.ABCMeta
@@ -236,3 +252,6 @@ class BaseMessenger(object):
 
     def remove_whitelisted_domains(self):
         return self.client.remove_whitelisted_domains()
+
+    def upload_attachment(self, attachment):
+        return self.client.upload_attachment(attachment)

--- a/fbmessenger/elements.py
+++ b/fbmessenger/elements.py
@@ -12,6 +12,7 @@ WEBVIEW_HEIGHT_RATIOS = [
     'full',
 ]
 
+
 class Text(object):
     def __init__(self, text, quick_replies=None):
         self.text = text

--- a/fbmessenger/templates.py
+++ b/fbmessenger/templates.py
@@ -138,6 +138,30 @@ class GenericTemplate(ElementMixin, SharableMixin, BaseTemplate):
         return super(GenericTemplate, self).to_dict()
 
 
+class MediaTemplate(BaseTemplate):
+    TEMPLATE_TYPE = 'media'
+
+    VALID_MEDIA_TYPES = ('image', 'video')
+
+    def __init__(self, media, buttons=None):
+        if media.attachment_type not in self.VALID_MEDIA_TYPES:
+            raise ValueError('Only image and video types are supported')
+        self.media = media
+        self.buttons = buttons
+        super(MediaTemplate, self).__init__()
+
+    def to_dict(self):
+        # Media's dict has an extra layer of structure we don't need
+        media_dict = self.media.to_dict()
+        element = media_dict['attachment']['payload']
+        element['media_type'] = self.media.attachment_type
+        if self.buttons:
+            element['buttons'] = [b.to_dict() for b in self.buttons]
+        self._d['attachment']['payload']['elements'] = [element]
+        return super(MediaTemplate, self).to_dict()
+
+
+
 class ButtonTemplate(ButtonMixin, BaseTemplate):
     TEMPLATE_TYPE = 'button'
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,12 @@
 from mock import Mock
 import pytest
 
-from fbmessenger import MessengerClient, thread_settings
+from fbmessenger import (
+    MessengerClient,
+    attachments,
+    quick_replies,
+    thread_settings,
+)
 
 
 @pytest.fixture
@@ -300,3 +305,51 @@ def test_remove_whitelisted_domains(client, monkeypatch):
             ],
         }
     )
+
+
+def test_upload_attachment(monkeypatch):
+    mock_post = Mock()
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "attachment_id": "12345",
+    }
+    monkeypatch.setattr('requests.Session.post', mock_post)
+
+    attachment = attachments.Image(url='https://some-image.com/image.jpg')
+    client = MessengerClient(page_access_token=12345678)
+    res = client.upload_attachment(attachment)
+    assert res == {"attachment_id": "12345"}
+    assert mock_post.call_count == 1
+    mock_post.assert_called_with(
+        'https://graph.facebook.com/v2.11/me/message_attachments',
+        params={
+            'access_token': 12345678,
+        },
+        json={
+            'message': {
+                'attachment': {
+                    'type': 'image',
+                    'payload': {
+                        'url': 'https://some-image.com/image.jpg'
+                    }
+                }
+            }
+        }
+    )
+
+
+def test_upload_url_required():
+    attachment = attachments.Image(attachment_id='12345')
+    client = MessengerClient(page_access_token=12345678)
+    with pytest.raises(ValueError):
+        client.upload_attachment(attachment)
+
+
+def test_upload_no_quick_replies():
+    replies = quick_replies.QuickReplies(
+        [quick_replies.QuickReply(title='hello', payload='hello')])
+    attachment = attachments.Image(
+        url='https://some-image.com/image.jpg', quick_replies=replies)
+    client = MessengerClient(page_access_token=12345678)
+    with pytest.raises(ValueError):
+        client.upload_attachment(attachment)

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -272,3 +272,14 @@ def test_remove_whitelisted_domains(messenger, monkeypatch):
     monkeypatch.setattr(messenger.client, 'remove_whitelisted_domains', mock)
     res = messenger.remove_whitelisted_domains()
     assert res == mock()
+
+
+def test_upload_attachment(messenger, monkeypatch):
+    mock = Mock()
+    mock.return_value = {
+        'attachment_id': 12345
+    }
+    monkeypatch.setattr(messenger.client, 'upload_attachment', mock)
+    attachment = {'some': 'data'}
+    res = messenger.upload_attachment(attachment)
+    assert res == mock()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -469,3 +469,8 @@ class TestTemplates:
             }
         }
         assert expected == res.to_dict()
+
+    def test_media_template_invalid(self):
+        bad_attachment = attachments.File(url='https://some/file.doc')
+        with pytest.raises(ValueError):
+            templates.MediaTemplate(bad_attachment)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,5 +1,6 @@
 import pytest
 
+from fbmessenger import attachments
 from fbmessenger import elements
 from fbmessenger import templates
 from fbmessenger import quick_replies
@@ -414,6 +415,56 @@ class TestTemplates:
                             'url': 'http://facebook.com'
                         }
                     ],
+                }
+            }
+        }
+        assert expected == res.to_dict()
+
+    def test_media_template(self):
+        btn = elements.Button(
+            button_type='web_url',
+            title='Web button',
+            url='http://facebook.com'
+        )
+        attachment = attachments.Image(attachment_id='12345')
+        res = templates.MediaTemplate(attachment, buttons=[btn])
+        expected = {
+            'attachment': {
+                'type': 'template',
+                'payload': {
+                    'template_type': 'media',
+                    'elements': [
+                        {
+                            'media_type': 'image',
+                            'attachment_id': '12345',
+                            'buttons': [
+                                {
+                                    'type': 'web_url',
+                                    'title': 'Web button',
+                                    'url': 'http://facebook.com'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+        assert expected == res.to_dict()
+
+    def test_media_template_no_buttons(self):
+        attachment = attachments.Image(attachment_id='12345')
+        res = templates.MediaTemplate(attachment)
+        expected = {
+            'attachment': {
+                'type': 'template',
+                'payload': {
+                    'template_type': 'media',
+                    'elements': [
+                        {
+                            'media_type': 'image',
+                            'attachment_id': '12345',
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
This change supports media templates: https://developers.facebook.com/docs/messenger-platform/send-messages/template/media

As part of this, it also adds support for uploading items to Facebook via the Attachment Upload API: https://developers.facebook.com/docs/messenger-platform/reference/attachment-upload-api