### PR TITLE
Require `messaging_type` for message sends

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 # Release History
+
+## 5.0.0
+- Breaking API change - `messaging_type` is now required when sending
+  a message.
+
 ## 4.1.0
 
 - Bring PersistentMenuItem up to date

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ class Messenger(BaseMessenger):
         super(Messenger, self).__init__(self.page_access_token)
 
     def message(self, message):
-        self.send({'text': 'Received: {0}'.format(message['message']['text'])})
+        self.send({'text': 'Received: {0}'.format(message['message']['text'])}, 'RESPONSE')
 
     def delivery(self, message):
         pass
@@ -123,22 +123,41 @@ Import the elements (or just the ones you need)
 
 	from fbmessenger import elements
 
+### Messaging type
+Starting from 7th May 2018, Facebook requires that all message sends
+must include the `messaging_type` property:
+
+  https://developers.facebook.com/docs/messenger-platform/reference/send-api
+
+This is passed in the `send()` calls below - in each case, we'll just
+use `RESPONSE`. You should use whatever value is appropriate for your
+application. Supported values are:
+
+- `RESPONSE`
+- `UPDATE`
+- `MESSAGE_TAG`
+- `NON_PROMOTIONAL_SUBSCRIPTION`
+
+
+See [Messaging Types](https://developers.facebook.com/docs/messenger-platform/send-messages/#messaging_types)
+for more information.
+
 ### Text
 
 You can pass a simple dict or use the Class
 
 ```python
-messenger.send({'text': msg})
+messenger.send({'text': msg}, 'RESPONSE')
 
 elem = elements.Text('Your Message')
-messenger.send(elem.to_dict())
+messenger.send(elem.to_dict(), 'RESPONSE')
 ```
 
 ### Web button
 
 ```python
 btn = elements.Button(title='Web button', url='http://example.com')
-messenger.send(btn.to_dict())
+messenger.send(btn.to_dict(), 'RESPONSE')
 ```
 
 ### Payload button
@@ -147,7 +166,7 @@ To use these buttons you must have the `message_deliveries` subscription enabled
 
 ```python
 btn = elements.Button(title='Postback button', payload='payload')
-messenger.send(btn.to_dict())
+messenger.send(btn.to_dict(), 'RESPONSE')
 ```
 
 <a name="attachments"></a>
@@ -157,28 +176,28 @@ messenger.send(btn.to_dict())
 
 ```python
 image = attachments.Image(url='http://example.com/image.jpg')
-messenger.send(image.to_dict())
+messenger.send(image.to_dict(), 'RESPONSE')
 ```
 
 ### Audio
 
 ```python
 audio = attachments.Image(url='http://example.com/audio.mp3')
-messenger.send(audio.to_dict())
+messenger.send(audio.to_dict(), 'RESPONSE')
 ```
 
 ### Video
 
 ```python
 video = attachments.Video(url='http://example.com/video.mp4')
-messenger.send(video.to_dict())
+messenger.send(video.to_dict(), 'RESPONSE')
 ```
 
 ### Files
 
 ```python
 file = attachments.File(url='http://example.com/file.txt')
-messenger.send(file.to_dict())
+messenger.send(file.to_dict(), 'RESPONSE')
 ```
 
 <a name="templates"></a>
@@ -202,7 +221,7 @@ elems = elements.Element(
     ]
 )
 res = templates.GenericTemplate(elements=[elems])
-messenger.send(res.to_dict())
+messenger.send(res.to_dict(), 'RESPONSE')
 ```
 
 ### Button template
@@ -214,7 +233,7 @@ res = templates.ButtonTemplate(
     text='Button template',
     buttons=[btn, btn2]
 )
-messenger.send(res.to_dict())
+messenger.send(res.to_dict(), 'RESPONSE')
 ```
 
 ### Receipt template
@@ -255,7 +274,7 @@ res = templates.ReceiptTemplate(
     adjustments=[adjustment1, adjustment2],
     elements=[element]
 )
-messenger.send(res.to_dict())
+messenger.send(res.to_dict(), 'RESPONSE')
 ```
 
 <a name="sender-actions"></a>
@@ -294,7 +313,7 @@ quick_replies = QuickReplies(quick_replies=[
 ])
 text = { text: 'A message' }
 text['quick_replies'] = quick_replies.to_dict()
-messenger.send(text)
+messenger.send(text, 'RESPONSE')
 ```
 
 <a name="thread-settings"></a>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,7 @@ def test_send_data(client, monkeypatch, entry):
     monkeypatch.setattr('requests.Session.post', mock_post)
     client = MessengerClient(page_access_token=12345678)
     payload = {'text': 'Test message'}
-    resp = client.send(payload, entry)
+    resp = client.send(payload, entry, 'RESPONSE')
 
     assert resp == {
         "recipient_id": 12345678,
@@ -85,12 +85,20 @@ def test_send_data(client, monkeypatch, entry):
         'https://graph.facebook.com/v2.11/me/messages',
         params={'access_token': 12345678},
         json={
+            'messaging_type': 'RESPONSE',
             'recipient': {
                 'id': entry['sender']['id']
             },
             'message': payload
         }
     )
+
+
+def test_send_data_invalid_message_type():
+    client = MessengerClient(page_access_token=12345678)
+    payload = {'text': 'Test message'}
+    with pytest.raises(ValueError):
+        client.send(payload, entry, 'INVALID')
 
 
 def test_send_action(client, monkeypatch, entry):

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -204,7 +204,7 @@ def test_send(messenger, monkeypatch):
         'success': True
     }
     monkeypatch.setattr(messenger.client, 'send', mock)
-    res = messenger.send({'text': 'message'})
+    res = messenger.send({'text': 'message'}, 'RESPONSE')
     assert res == mock()
 
 


### PR DESCRIPTION
Note that this is a breaking API change, to reflect the fact that Facebook themselves are making a breaking API change:

https://developers.facebook.com/docs/messenger-platform/send-messages/#messaging_types

From May 7th, this field will be required on all message sends.

I've bumped the major version of the library accordingly.