### PR TITLE
Add support for `notification_type`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 5.1.0
+- Add support for `notification_type` in the Send API.
+
 ## 5.0.0
 - Breaking API change - `messaging_type` is now required when sending
   a message.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ application. Supported values are:
 See [Messaging Types](https://developers.facebook.com/docs/messenger-platform/send-messages/#messaging_types)
 for more information.
 
+### Notification Type
+
+Any of the elements below may be sent in conjunction with a notification
+type (see the [Send API documentation](https://developers.facebook.com/docs/messenger-platform/reference/send-api/)
+for more details). `notification_type` is an optional parameter to the
+`.send()` call. For example:
+
+```python
+messenger.send({'text': msg}, 'RESPONSE', notification_type='SILENT_PUSH')
+```
+
+Supported values are are:
+- `REGULAR`
+- `SILENT_PUSH`
+- `NO_PUSH`
+
+If a value is not provided, then the notification preference will not
+be set and Facebook Messenger's default will apply (which is `REGULAR`
+at the time of writing).
+
 ### Text
 
 You can pass a simple dict or use the Class


### PR DESCRIPTION
This adds support for notification_type (https://developers.facebook.com/docs/messenger-platform/reference/send-api/). It controls how the user is notified about an outgoing message.

I've added this as an argument to the send call, as it feels more like metadata about the send than a property of the message itself. It's backward compatible, so I've just incremented the minor version.

I also made some minor test cleanups, using a fixture instead of repeated creation of a messenger client instance.

Let me know if you need any changes!