### PR TITLE
Add dynamic text support

### DIFF
--- a/fbmessenger/elements.py
+++ b/fbmessenger/elements.py
@@ -29,6 +29,30 @@ class Text(object):
         return d
 
 
+class DynamicText(object):
+    def __init__(self, text, fallback_text=None, quick_replies=None):
+        self.text = text
+        self.fallback_text = fallback_text
+        self.quick_replies = quick_replies
+
+    def to_dict(self):
+        dynamic_text = {
+            'text': self.text,
+        }
+
+        if self.fallback_text:
+            dynamic_text['fallback_text'] = self.fallback_text
+
+        d = {
+            'dynamic_text': dynamic_text,
+        }
+
+        if self.quick_replies:
+            d['quick_replies'] = self.quick_replies.to_dict()
+
+        return d
+
+
 class Button(object):
     BUTTON_TYPES = [
         'web_url',

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -37,6 +37,35 @@ class TestElements:
         }
         assert expected == res.to_dict()
 
+    def test_dynamic_text(self):
+        res = elements.DynamicText('Hi, {{first_name}}!', 'Hello friend!')
+        expected = {
+            'dynamic_text': {
+                'text': 'Hi, {{first_name}}!',
+                'fallback_text': 'Hello friend!',
+            },
+        }
+        assert expected == res.to_dict()
+
+    def test_dynamic_text_with_quick_replies(self):
+        qr = quick_replies.QuickReply(title='QR', payload='QR payload')
+        qrs = quick_replies.QuickReplies(quick_replies=[qr])
+        res = elements.DynamicText('Hi, {{first_name}}!', 'Hello friend!', quick_replies=qrs)
+        expected = {
+            'dynamic_text': {
+                'text': 'Hi, {{first_name}}!',
+                'fallback_text': 'Hello friend!',
+            },
+            'quick_replies': [
+                {
+                    'content_type': 'text',
+                    'title': 'QR',
+                    'payload': 'QR payload'
+                },
+            ],
+        }
+        assert expected == res.to_dict()
+
     def test_web_button(self):
         res = elements.Button(button_type='web_url', title='Web button', url='http://facebook.com')
         expected = {


### PR DESCRIPTION
This adds support for dynamic_text element, which is not very well documented, but appears in the [broadcast docs](https://developers.facebook.com/docs/messenger-platform/send-messages/broadcast-messages#personalization).