### PR TITLE
Sessions and Timeouts

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 5.2.0
+- The caller may now pass their own `requests.Session` object to
+  `MessengerClient`. This is useful for eg. configuring retry behaviour.
+
 ## 5.1.0
 - Add support for `notification_type` in the Send API.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 ## 5.2.0
 - The caller may now pass their own `requests.Session` object to
   `MessengerClient`. This is useful for eg. configuring retry behaviour.
+- Every method that causes network access now accepts a `timeout`
+  parameter.
 
 ## 5.1.0
 - Add support for `notification_type` in the Send API.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A python library to communicate with the Facebook Messenger API's
 
 - [Installation](#installation)
 - [Example usage with Flask](#example-usage-with-flask)
+- [Timeouts](#timeouts)
 - [Elements](#elements)
 - [Attachments](#attachments)
 - [Templates](#templates)
@@ -115,6 +116,27 @@ if __name__ == "__main__":
     app.run(host='0.0.0.0')
 ```
 
+<a name="timeouts"></a>
+## Timeouts
+Any method on either the `BaseMessenger` or `MessengerClient` classes
+which perform network access accept an optional `timeout` parameter.
+This should be a number, and causes an exception to be raised if the
+server (ie. Facebook) has not started responding within `timeout`
+seconds (more precisely, if no bytes have been received on the
+underlying socket for `timeout` seconds). If no timeout is specified
+explicitly, requests do not time out. Note that in particular,
+`timeout` is *not* a time limit on the entire response download - just
+the initial connection.
+
+For example, this call will raise a socket timeout exception if
+the start of a response has not been received within 10 seconds:
+
+```
+messenger.send({'text': msg}, 'RESPONSE', timeout=10)
+```
+
+If no `timeout` is provided (the default) then connection attempts will
+not time out.
 
 <a name="elements"></a>
 ## Elements

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -32,17 +32,19 @@ class MessengerClient(object):
             session = requests.Session()
         self.session = session
 
-    def get_user_data(self, entry):
+    def get_user_data(self, entry, timeout=None):
         r = self.session.get(
             'https://graph.facebook.com/v2.11/{sender}'.format(sender=entry['sender']['id']),
             params={
                 'fields': 'first_name,last_name,profile_pic,locale,timezone,gender',
                 'access_token': self.page_access_token
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def send(self, payload, entry, messaging_type, notification_type=None):
+    def send(self, payload, entry, messaging_type, notification_type=None,
+             timeout=None):
         if messaging_type not in self.MESSAGING_TYPES:
             raise ValueError(
                 '`{}` is not a valid `messaging_type`'.format(messaging_type))
@@ -67,11 +69,12 @@ class MessengerClient(object):
             params={
                 'access_token': self.page_access_token
             },
-            json=body
+            json=body,
+            timeout=timeout
         )
         return r.json()
 
-    def send_action(self, sender_action, entry):
+    def send_action(self, sender_action, entry, timeout=None):
         r = self.session.post(
             'https://graph.facebook.com/v2.11/me/messages',
             params={
@@ -82,30 +85,33 @@ class MessengerClient(object):
                     'id': entry['sender']['id']
                 },
                 'sender_action': sender_action
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def subscribe_app_to_page(self):
+    def subscribe_app_to_page(self, timeout=None):
         r = self.session.post(
             'https://graph.facebook.com/v2.11/me/subscribed_apps',
             params={
                 'access_token': self.page_access_token
-            }
+            },
+            timeout=None
         )
         return r.json()
 
-    def set_messenger_profile(self, data):
+    def set_messenger_profile(self, data, timeout=None):
         r = self.session.post(
             'https://graph.facebook.com/v2.11/me/messenger_profile',
             params={
                 'access_token': self.page_access_token
             },
-            json=data
+            json=data,
+            timeout=timeout
         )
         return r.json()
 
-    def delete_get_started(self):
+    def delete_get_started(self, timeout=None):
         r = self.session.delete(
             'https://graph.facebook.com/v2.11/me/messenger_profile',
             params={
@@ -115,11 +121,12 @@ class MessengerClient(object):
                 'fields':[
                     'get_started'
                 ],
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def delete_persistent_menu(self):
+    def delete_persistent_menu(self, timeout=None):
         r = self.session.delete(
             'https://graph.facebook.com/v2.11/me/messenger_profile',
             params={
@@ -129,22 +136,24 @@ class MessengerClient(object):
                 'fields':[
                     'persistent_menu'
                 ],
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def link_account(self, account_linking_token):
+    def link_account(self, account_linking_token, timeout=None):
         r = self.session.post(
             'https://graph.facebook.com/v2.11/me',
             params={
                 'access_token': self.page_access_token,
                 'fields': 'recipient',
                 'account_linking_token': account_linking_token
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def unlink_account(self, psid):
+    def unlink_account(self, psid, timeout=None):
         r = self.session.post(
             'https://graph.facebook.com/v2.11/me/unlink_accounts',
             params={
@@ -152,11 +161,12 @@ class MessengerClient(object):
             },
             json={
                 'psid': psid
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def update_whitelisted_domains(self, domains):
+    def update_whitelisted_domains(self, domains, timeout=None):
         if not isinstance(domains, list):
             domains = [domains]
         r = self.session.post(
@@ -166,11 +176,12 @@ class MessengerClient(object):
             },
             json={
                 'whitelisted_domains': domains
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def remove_whitelisted_domains(self):
+    def remove_whitelisted_domains(self, timeout=None):
         r = self.session.delete(
             'https://graph.facebook.com/v2.11/me/messenger_profile',
             params={
@@ -180,11 +191,12 @@ class MessengerClient(object):
                 'fields':[
                     'whitelisted_domains'
                 ],
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 
-    def upload_attachment(self, attachment):
+    def upload_attachment(self, attachment, timeout=None):
         if not attachment.url:
             raise ValueError('Attachment must have `url` specified')
         if attachment.quick_replies:
@@ -196,7 +208,8 @@ class MessengerClient(object):
             },
             json={
                 'message':  attachment.to_dict()
-            }
+            },
+            timeout=timeout
         )
         return r.json()
 

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -264,38 +264,40 @@ class BaseMessenger(object):
                 elif message.get('read'):
                     return self.read(message)
 
-    def get_user(self):
-        return self.client.get_user_data(self.last_message)
+    def get_user(self, timeout=None):
+        return self.client.get_user_data(self.last_message, timeout=timeout)
 
-    def send(self, payload, messaging_type):
-        return self.client.send(payload, self.last_message, messaging_type)
+    def send(self, payload, messaging_type, timeout=None):
+        return self.client.send(
+            payload, self.last_message, messaging_type, timeout=timeout)
 
-    def send_action(self, sender_action):
-        return self.client.send_action(sender_action, self.last_message)
+    def send_action(self, sender_action, timeout=None):
+        return self.client.send_action(
+            sender_action, self.last_message, timeout=timeout)
 
     def get_user_id(self):
         return self.last_message['sender']['id']
 
-    def subscribe_app_to_page(self):
-        return self.client.subscribe_app_to_page()
+    def subscribe_app_to_page(self, timeout=None):
+        return self.client.subscribe_app_to_page(timeout=timeout)
 
-    def set_messenger_profile(self, data):
-        return self.client.set_messenger_profile(data)
+    def set_messenger_profile(self, data, timeout=None):
+        return self.client.set_messenger_profile(data, timeout=timeout)
 
-    def delete_get_started(self):
-        return self.client.delete_get_started()
+    def delete_get_started(self, timeout=None):
+        return self.client.delete_get_started(timeout=timeout)
 
-    def link_account(self, account_linking_token):
-        return self.client.link_account(account_linking_token)
+    def link_account(self, account_linking_token, timeout=None):
+        return self.client.link_account(account_linking_token, timeout=timeout)
 
-    def unlink_account(self, psid):
-        return self.client.unlink_account(psid)
+    def unlink_account(self, psid, timeout=None):
+        return self.client.unlink_account(psid, timeout=timeout)
 
-    def add_whitelisted_domains(self, domains):
-        return self.client.update_whitelisted_domains(domains)
+    def add_whitelisted_domains(self, domains, timeout=None):
+        return self.client.update_whitelisted_domains(domains, timeout=timeout)
 
-    def remove_whitelisted_domains(self):
-        return self.client.remove_whitelisted_domains()
+    def remove_whitelisted_domains(self, timeout=None):
+        return self.client.remove_whitelisted_domains(timeout=timeout)
 
-    def upload_attachment(self, attachment):
-        return self.client.upload_attachment(attachment)
+    def upload_attachment(self, attachment, timeout=None):
+        return self.client.upload_attachment(attachment, timeout=timeout)

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 import requests
 
-__version__ = '5.1.0'
+__version__ = '5.2.0'
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +26,11 @@ class MessengerClient(object):
         'NO_PUSH'
     }
 
-    def __init__(self, page_access_token):
+    def __init__(self, page_access_token, session=None):
         self.page_access_token = page_access_token
-        self.session = requests.Session()
+        if session is None:
+            session = requests.Session()
+        self.session = session
 
     def get_user_data(self, entry):
         r = self.session.get(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,7 +47,8 @@ def test_get_user_data(client, monkeypatch):
         params={
             'fields': 'first_name,last_name,profile_pic,locale,timezone,gender',
             'access_token': 12345678
-        }
+        },
+        timeout=None
     )
 
 
@@ -64,7 +65,8 @@ def test_subscribe_app_to_page(client, monkeypatch):
     assert mock_post.call_count == 1
     mock_post.assert_called_with(
         'https://graph.facebook.com/v2.11/me/subscribed_apps',
-        params={'access_token': 12345678}
+        params={'access_token': 12345678},
+        timeout=None
     )
 
 
@@ -93,7 +95,8 @@ def test_send_data(client, monkeypatch, entry):
                 'id': entry['sender']['id']
             },
             'message': payload
-        }
+        },
+        timeout=None
     )
 
 
@@ -118,7 +121,8 @@ def test_send_data_notification_type(client, monkeypatch, entry):
             },
             'message': payload,
             'notification_type': 'SILENT_PUSH'
-        }
+        },
+        timeout=None
     )
 
 
@@ -149,7 +153,8 @@ def test_send_action(client, monkeypatch, entry):
                 'id': entry['sender']['id']
             },
             'sender_action': 'typing_on'
-        }
+        },
+        timeout=None
     )
 
 
@@ -174,7 +179,8 @@ def test_set_greeting_text(client, monkeypatch):
                 'locale': 'default',
                 'text': 'Welcome message'
             }]
-        }
+        },
+        timeout=None
     )
 
 
@@ -205,7 +211,8 @@ def test_delete_get_started(client, monkeypatch):
             'fields': [
                 'get_started',
             ],
-        }
+        },
+        timeout=None
     )
 
 
@@ -223,7 +230,8 @@ def test_delete_persistent_menu(client, monkeypatch):
             'fields': [
                 'persistent_menu',
             ],
-        }
+        },
+        timeout=None
     )
 
 
@@ -240,7 +248,8 @@ def test_link_account(client, monkeypatch):
             'access_token': 12345678,
             'fields': 'recipient',
             'account_linking_token': 1234
-        }
+        },
+        timeout=None
     )
 
 
@@ -261,7 +270,8 @@ def test_unlink_account(client, monkeypatch):
         },
         json={
             'psid': 1234
-        }
+        },
+        timeout=None
     )
 
 
@@ -284,7 +294,8 @@ def test_add_whitelisted_domains(client, monkeypatch):
             'whitelisted_domains': [
                 'https://facebook.com'
             ],
-        }
+        },
+        timeout=None
     )
 
 
@@ -307,7 +318,8 @@ def test_add_whitelisted_domains_not_as_list(client, monkeypatch):
             'whitelisted_domains': [
                 'https://facebook.com'
             ],
-        }
+        },
+        timeout=None
     )
 
 
@@ -330,7 +342,8 @@ def test_remove_whitelisted_domains(client, monkeypatch):
             'fields': [
                 'whitelisted_domains',
             ],
-        }
+        },
+        timeout=None
     )
 
 
@@ -360,7 +373,8 @@ def test_upload_attachment(client, monkeypatch):
                     }
                 }
             }
-        }
+        },
+        timeout=None
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
-from mock import Mock
+import requests
+import mock
 import pytest
 
 from fbmessenger import (
@@ -24,7 +25,7 @@ def entry():
 
 
 def test_get_user_data(client, monkeypatch):
-    mock_get = Mock()
+    mock_get = mock.Mock()
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
         "first_name": "Test",
@@ -37,7 +38,6 @@ def test_get_user_data(client, monkeypatch):
             'id': 12345678
         }
     }
-    client = MessengerClient(page_access_token=12345678)
     resp = client.get_user_data(entry)
 
     assert resp == {"first_name": "Test", "last_name": "User", "profile_pic": "profile"}
@@ -52,7 +52,7 @@ def test_get_user_data(client, monkeypatch):
 
 
 def test_subscribe_app_to_page(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "success": True
@@ -69,7 +69,7 @@ def test_subscribe_app_to_page(client, monkeypatch):
 
 
 def test_send_data(client, monkeypatch, entry):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "recipient_id": 12345678,
@@ -98,7 +98,7 @@ def test_send_data(client, monkeypatch, entry):
 
 
 def test_send_data_notification_type(client, monkeypatch, entry):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "recipient_id": 12345678,
@@ -135,7 +135,7 @@ def test_send_data_invalid_message_type(client, entry):
 
 
 def test_send_action(client, monkeypatch, entry):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     monkeypatch.setattr('requests.Session.post', mock_post)
     client.send_action('typing_on', entry)
@@ -154,7 +154,7 @@ def test_send_action(client, monkeypatch, entry):
 
 
 def test_set_greeting_text(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "result": "success"
@@ -179,7 +179,7 @@ def test_set_greeting_text(client, monkeypatch):
 
 
 def test_set_greeting_text_too_long(monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "result": "success"
@@ -192,7 +192,7 @@ def test_set_greeting_text_too_long(monkeypatch):
 
 
 def test_delete_get_started(client, monkeypatch):
-    mock_delete = Mock()
+    mock_delete = mock.Mock()
     mock_delete.return_value.status_code = 200
     monkeypatch.setattr('requests.Session.delete', mock_delete)
     client.delete_get_started()
@@ -210,7 +210,7 @@ def test_delete_get_started(client, monkeypatch):
 
 
 def test_delete_persistent_menu(client, monkeypatch):
-    mock_delete = Mock()
+    mock_delete = mock.Mock()
     mock_delete.return_value.status_code = 200
     monkeypatch.setattr('requests.Session.delete', mock_delete)
     client.delete_persistent_menu()
@@ -228,7 +228,7 @@ def test_delete_persistent_menu(client, monkeypatch):
 
 
 def test_link_account(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     monkeypatch.setattr('requests.Session.post', mock_post)
     client.link_account(1234)
@@ -245,7 +245,7 @@ def test_link_account(client, monkeypatch):
 
 
 def test_unlink_account(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "result": "unlink account success"
@@ -266,7 +266,7 @@ def test_unlink_account(client, monkeypatch):
 
 
 def test_add_whitelisted_domains(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "result": "success",
@@ -289,7 +289,7 @@ def test_add_whitelisted_domains(client, monkeypatch):
 
 
 def test_add_whitelisted_domains_not_as_list(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "result": "success",
@@ -312,7 +312,7 @@ def test_add_whitelisted_domains_not_as_list(client, monkeypatch):
 
 
 def test_remove_whitelisted_domains(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "result": "success",
@@ -335,7 +335,7 @@ def test_remove_whitelisted_domains(client, monkeypatch):
 
 
 def test_upload_attachment(client, monkeypatch):
-    mock_post = Mock()
+    mock_post = mock.Mock()
     mock_post.return_value.status_code = 200
     mock_post.return_value.json.return_value = {
         "attachment_id": "12345",
@@ -377,3 +377,12 @@ def test_upload_no_quick_replies(client):
         url='https://some-image.com/image.jpg', quick_replies=replies)
     with pytest.raises(ValueError):
         client.upload_attachment(attachment)
+
+
+def test_default_session(client):
+    assert isinstance(client.session, requests.Session)
+
+
+def test_explicit_session():
+    client = MessengerClient(12345678, session=mock.sentinel.session)
+    assert client.session is mock.sentinel.session

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -196,6 +196,7 @@ def test_get_user(messenger, monkeypatch):
         'last_name': 'McTestface',
         'profile': 'profile'
     }
+    mock.assert_called_with({}, timeout=None)
 
 
 def test_send(messenger, monkeypatch):
@@ -205,14 +206,16 @@ def test_send(messenger, monkeypatch):
     }
     monkeypatch.setattr(messenger.client, 'send', mock)
     res = messenger.send({'text': 'message'}, 'RESPONSE')
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with({'text': 'message'}, {}, 'RESPONSE', timeout=None)
 
 
 def test_send_action(messenger, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(messenger.client, 'send_action', mock)
     res = messenger.send_action('typing_on')
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with('typing_on', {}, timeout=None)
 
 
 def test_set_thread_setting(messenger, monkeypatch):
@@ -224,7 +227,14 @@ def test_set_thread_setting(messenger, monkeypatch):
     welcome_message = thread_settings.GreetingText(text='Welcome message')
     profile = thread_settings.MessengerProfile(greetings=[welcome_message])
     res = messenger.set_messenger_profile(profile.to_dict())
-    assert res == mock()
+    assert res == mock.return_value
+    greeting = {
+        'greeting': [{
+            'locale': 'default',
+            'text': 'Welcome message'
+        }]
+    }
+    mock.assert_called_with(greeting, timeout=None)
 
 
 def test_delete_get_started(messenger, monkeypatch):
@@ -234,14 +244,16 @@ def test_delete_get_started(messenger, monkeypatch):
     }
     monkeypatch.setattr(messenger.client, 'delete_get_started', mock)
     res = messenger.delete_get_started()
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with(timeout=None)
 
 
 def test_link_account(messenger, monkeypatch):
     mock = Mock()
     monkeypatch.setattr(messenger.client, 'link_account', mock)
     res = messenger.link_account(1234)
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with(1234, timeout=None)
 
 
 def test_unlink_account(messenger, monkeypatch):
@@ -251,7 +263,8 @@ def test_unlink_account(messenger, monkeypatch):
     }
     monkeypatch.setattr(messenger.client, 'unlink_account', mock)
     res = messenger.unlink_account(1234)
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with(1234, timeout=None)
 
 
 def test_add_whitelisted_domains(messenger, monkeypatch):
@@ -261,7 +274,8 @@ def test_add_whitelisted_domains(messenger, monkeypatch):
     }
     monkeypatch.setattr(messenger.client, 'update_whitelisted_domains', mock)
     res = messenger.add_whitelisted_domains('https://facebook.com')
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with('https://facebook.com', timeout=None)
 
 
 def test_remove_whitelisted_domains(messenger, monkeypatch):
@@ -271,7 +285,8 @@ def test_remove_whitelisted_domains(messenger, monkeypatch):
     }
     monkeypatch.setattr(messenger.client, 'remove_whitelisted_domains', mock)
     res = messenger.remove_whitelisted_domains()
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with(timeout=None)
 
 
 def test_upload_attachment(messenger, monkeypatch):
@@ -282,4 +297,5 @@ def test_upload_attachment(messenger, monkeypatch):
     monkeypatch.setattr(messenger.client, 'upload_attachment', mock)
     attachment = {'some': 'data'}
     res = messenger.upload_attachment(attachment)
-    assert res == mock()
+    assert res == mock.return_value
+    mock.assert_called_with(attachment, timeout=None)


### PR DESCRIPTION
This change improves general network robustness - it allows (for example) retries, by allowing the caller to pass a pre-configured `requests.Session` object to `MessengerClient`. Also, (hopefully!) all method calls that perform network access now accept a `timeout` parameter, which is simply passed through to requests.

Happy to make any tweaks needed here!

