### PR TITLE
Adding 2 quick replies content_type: userphone_number, user_mail

### DIFF
--- a/fbmessenger/quick_replies.py
+++ b/fbmessenger/quick_replies.py
@@ -11,7 +11,9 @@ class QuickReply(object):
 
     CONTENT_TYPES = [
         'text',
-        'location'
+        'location',
+        'user_phone_number',
+        'user_email'
     ]
 
     def __init__(self, title=None, payload=None, image_url=None, content_type=None):


### PR DESCRIPTION
This pull request add the 2 missing quick replies content types: user_email, user_phone_number : https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies