### PR TITLE
fix: add fields parameter to `MessengerClient:get_user_data`

### DIFF
--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -31,11 +31,11 @@ class MessengerClient(object):
             session = requests.Session()
         self.session = session
 
-    def get_user_data(self, entry, timeout=None):
+    def get_user_data(self, entry, fields=None, timeout=None):
         r = self.session.get(
             'https://graph.facebook.com/v2.11/{sender}'.format(sender=entry['sender']['id']),
             params={
-                'fields': 'first_name,last_name,profile_pic,locale,timezone,gender',
+                'fields': 'first_name,last_name,profile_pic,locale,timezone,gender' if fields is None else fields,
                 'access_token': self.page_access_token
             },
             timeout=timeout
@@ -266,8 +266,8 @@ class BaseMessenger(object):
                 elif message.get('read'):
                     return self.read(message)
 
-    def get_user(self, timeout=None):
-        return self.client.get_user_data(self.last_message, timeout=timeout)
+    def get_user(self, fields=None, timeout=None):
+        return self.client.get_user_data(self.last_message, fields=fields, timeout=timeout)
 
     def send(self, payload, messaging_type, timeout=None, tag=None):
         return self.client.send(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,6 +52,33 @@ def test_get_user_data(client, monkeypatch):
     )
 
 
+def test_get_user_data_fields(client, monkeypatch):
+    mock_get = mock.Mock()
+    mock_get.return_value.status_code == 200
+    mock_get.return_value.json.return_value = {
+        "first_name": "Test",
+        "last_name": "User",
+    }
+    monkeypatch.setattr('requests.Session.get', mock_get)
+    entry = {
+        'sender': {
+            'id': 12345678
+        }
+    }
+    resp = client.get_user_data(entry, fields='first_name,last_name')
+
+    assert resp == {"first_name": "Test", "last_name": "User"}
+    assert mock_get.call_count == 1
+    mock_get.assert_called_with(
+        'https://graph.facebook.com/v2.11/12345678',
+        params={
+            'fields': 'first_name,last_name',
+            'access_token': 12345678
+        },
+        timeout=None
+    )
+
+
 def test_subscribe_app_to_page(client, monkeypatch):
     mock_post = mock.Mock()
     mock_post.return_value.status_code = 200

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -196,7 +196,7 @@ def test_get_user(messenger, monkeypatch):
         'last_name': 'McTestface',
         'profile': 'profile'
     }
-    mock.assert_called_with({}, timeout=None)
+    mock.assert_called_with({}, fields=None, timeout=None)
 
 
 def test_send(messenger, monkeypatch):


### PR DESCRIPTION
Always requesting all these fields will soon require developers to obtain several additional permissions (see: https://developers.facebook.com/docs/messenger-platform/identity/user-profile/). It would be nice to have a way to request fewer fields, so this PR makes the `fields` parameter configurable.