### PR TITLE
Add defaults for messaging_type & notification_type 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 5.6.1
 - Update README
 - remove pytest-catchlog from requirements.txt
+- Add defaults for messaging_type & notification_type
+- Add notification_type to BaseMessenger.send
 
 ## 5.6.0
 - Adds app secret support

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ for more details). `notification_type` is an optional parameter to the
 `.send()` call. For example:
 
 ```python
-messenger.send({'text': msg}, 'RESPONSE', notification_type='SILENT_PUSH')
+messenger.send({'text': msg}, 'RESPONSE', notification_type='REGULAR')
 ```
 
 Supported values are are:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This is passed in the `send()` calls below - in each case, we'll just
 use `RESPONSE`. You should use whatever value is appropriate for your
 application. Supported values are:
 
-- `RESPONSE`
+- `RESPONSE` _(default)_
 - `UPDATE`
 - `MESSAGE_TAG`
 
@@ -178,13 +178,9 @@ messenger.send({'text': msg}, 'RESPONSE', notification_type='SILENT_PUSH')
 ```
 
 Supported values are are:
-- `REGULAR`
+- `REGULAR` _(default)_
 - `SILENT_PUSH`
 - `NO_PUSH`
-
-If a value is not provided, then the notification preference will not
-be set and Facebook Messenger's default will apply (which is `REGULAR`
-at the time of writing).
 
 ### Message Tags
 

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -299,8 +299,7 @@ class BaseMessenger(object):
                                 notification_type=notification_type, timeout=timeout, tag=tag)
 
     def send_action(self, sender_action, timeout=None):
-        return self.client.send_action(
-            sender_action, self.last_message, timeout=timeout)
+        return self.client.send_action(sender_action, self.last_message, timeout=timeout)
 
     def get_user_id(self):
         return self.last_message['sender']['id']

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -77,13 +77,16 @@ class MessengerClient(object):
         )
         return r.json()
 
-    def send(self, payload, entry, messaging_type, notification_type=None, timeout=None, tag=None):
+    def send(self, payload, entry, messaging_type=None, notification_type=None, timeout=None, tag=None):
         if messaging_type not in self.MESSAGING_TYPES:
-            raise ValueError(
-                '`{}` is not a valid `messaging_type`'.format(messaging_type))
+            messaging_type = 'RESPONSE'
+
+        if notification_type not in self.NOTIFICATION_TYPES:
+            notification_type = 'REGULAR'
 
         body = {
             'messaging_type': messaging_type,
+            'notification_type': notification_type,
             'recipient': {
                 'id': entry['sender']['id']
             },
@@ -92,13 +95,6 @@ class MessengerClient(object):
 
         if tag:
             body['tag'] = tag
-
-        if notification_type:
-            if notification_type not in self.NOTIFICATION_TYPES:
-                raise ValueError(
-                    '`{}` is not a valid `notification_type`'.format(
-                        notification_type))
-            body['notification_type'] = notification_type
 
         r = self.session.post(
             '{graph_url}/me/messages'.format(graph_url=self.graph_url),
@@ -294,8 +290,8 @@ class BaseMessenger(object):
     def get_user(self, fields=None, timeout=None):
         return self.client.get_user_data(self.last_message, fields=fields, timeout=timeout)
 
-    def send(self, payload, messaging_type, notification_type=None, timeout=None, tag=None):
-        return self.client.send(payload, self.last_message, messaging_type,
+    def send(self, payload, messaging_type=None, notification_type=None, timeout=None, tag=None):
+        return self.client.send(payload, self.last_message, messaging_type=messaging_type,
                                 notification_type=notification_type, timeout=timeout, tag=tag)
 
     def send_action(self, sender_action, timeout=None):

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -77,8 +77,7 @@ class MessengerClient(object):
         )
         return r.json()
 
-    def send(self, payload, entry, messaging_type, notification_type=None,
-             timeout=None, tag=None):
+    def send(self, payload, entry, messaging_type, notification_type=None, timeout=None, tag=None):
         if messaging_type not in self.MESSAGING_TYPES:
             raise ValueError(
                 '`{}` is not a valid `messaging_type`'.format(messaging_type))
@@ -295,9 +294,9 @@ class BaseMessenger(object):
     def get_user(self, fields=None, timeout=None):
         return self.client.get_user_data(self.last_message, fields=fields, timeout=timeout)
 
-    def send(self, payload, messaging_type, timeout=None, tag=None):
-        return self.client.send(
-            payload, self.last_message, messaging_type, timeout=timeout, tag=tag)
+    def send(self, payload, messaging_type, notification_type=None, timeout=None, tag=None):
+        return self.client.send(payload, self.last_message, messaging_type,
+                                notification_type=notification_type, timeout=timeout, tag=tag)
 
     def send_action(self, sender_action, timeout=None):
         return self.client.send_action(

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -16,14 +16,14 @@ DEFAULT_API_VERSION = 2.12
 
 class MessengerClient(object):
 
-    # https://developers.facebook.com/docs/messenger-platform/send-messages#send_api_basics
+    # https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types
     MESSAGING_TYPES = {
         'RESPONSE',
         'UPDATE',
         'MESSAGE_TAG',
     }
 
-    # https://developers.facebook.com/docs/messenger-platform/reference/send-api/
+    # https://developers.facebook.com/docs/messenger-platform/reference/send-api/#payload
     NOTIFICATION_TYPES = {
         'REGULAR',
         'SILENT_PUSH',
@@ -77,12 +77,12 @@ class MessengerClient(object):
         )
         return r.json()
 
-    def send(self, payload, entry, messaging_type=None, notification_type=None, timeout=None, tag=None):
+    def send(self, payload, entry, messaging_type='RESPONSE', notification_type='REGULAR', timeout=None, tag=None):
         if messaging_type not in self.MESSAGING_TYPES:
-            messaging_type = 'RESPONSE'
+            raise ValueError('`{}` is not a valid `messaging_type`'.format(messaging_type))
 
         if notification_type not in self.NOTIFICATION_TYPES:
-            notification_type = 'REGULAR'
+            raise ValueError('`{}` is not a valid `notification_type`'.format(notification_type))
 
         body = {
             'messaging_type': messaging_type,
@@ -122,7 +122,7 @@ class MessengerClient(object):
         r = self.session.post(
             '{graph_url}/me/subscribed_apps'.format(graph_url=self.graph_url),
             params=self.auth_args,
-            timeout=None
+            timeout=timeout
         )
         return r.json()
 
@@ -290,7 +290,7 @@ class BaseMessenger(object):
     def get_user(self, fields=None, timeout=None):
         return self.client.get_user_data(self.last_message, fields=fields, timeout=timeout)
 
-    def send(self, payload, messaging_type=None, notification_type=None, timeout=None, tag=None):
+    def send(self, payload, messaging_type='RESPONSE', notification_type='REGULAR', timeout=None, tag=None):
         return self.client.send(payload, self.last_message, messaging_type=messaging_type,
                                 notification_type=notification_type, timeout=timeout, tag=tag)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -182,6 +182,7 @@ def test_send_data(client, monkeypatch, entry):
         },
         json={
             'messaging_type': 'RESPONSE',
+            'notification_type': 'REGULAR',
             'recipient': {
                 'id': entry['sender']['id'],
             },
@@ -210,11 +211,11 @@ def test_send_data_notification_type(client, monkeypatch, entry):
         },
         json={
             'messaging_type': 'RESPONSE',
+            'notification_type': 'SILENT_PUSH',
             'recipient': {
                 'id': entry['sender']['id'],
             },
             'message': payload,
-            'notification_type': 'SILENT_PUSH',
         },
         timeout=None
     )
@@ -251,6 +252,7 @@ def test_send_data_with_tag(client, monkeypatch, entry):
         },
         json={
             'messaging_type': 'MESSAGE_TAG',
+            'notification_type': 'REGULAR',
             'recipient': {
                 'id': entry['sender']['id'],
             },

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -207,7 +207,8 @@ def test_send(messenger, monkeypatch):
     monkeypatch.setattr(messenger.client, 'send', mock)
     res = messenger.send({'text': 'message'}, 'RESPONSE')
     assert res == mock.return_value
-    mock.assert_called_with({'text': 'message'}, {}, 'RESPONSE', notification_type=None, timeout=None, tag=None)
+    mock.assert_called_with({'text': 'message'}, {}, messaging_type='RESPONSE', notification_type='REGULAR',
+                            timeout=None, tag=None)
 
 
 def test_send_action(messenger, monkeypatch):

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -207,7 +207,7 @@ def test_send(messenger, monkeypatch):
     monkeypatch.setattr(messenger.client, 'send', mock)
     res = messenger.send({'text': 'message'}, 'RESPONSE')
     assert res == mock.return_value
-    mock.assert_called_with({'text': 'message'}, {}, 'RESPONSE', timeout=None, tag=None)
+    mock.assert_called_with({'text': 'message'}, {}, 'RESPONSE', notification_type=None, timeout=None, tag=None)
 
 
 def test_send_action(messenger, monkeypatch):


### PR DESCRIPTION
Fixes #56 
Fixes #57 

Summary of changes proposed in this Pull Request:
- add notification_type to BaseMessenger.send 
- add defaults for messaging_type & notification_type 
- update links
- use timeout instaed of None in subscribe_app_to_page

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change