### PR TITLE
Remove support for share button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Unreleased
+- Remove share button support (deprecated by Facebook)
+
 ## 6.0.0
 - Switch from message to recipient_id as method input
 

--- a/fbmessenger/elements.py
+++ b/fbmessenger/elements.py
@@ -60,7 +60,6 @@ class Button(object):
         'phone_number',
         'account_link',
         'account_unlink',
-        'element_share',
     ]
 
     def __init__(self, button_type, title=None, url=None,
@@ -103,9 +102,6 @@ class Button(object):
                 d['messenger_extensions'] = 'true'
             if self.fallback_url:
                 d['fallback_url'] = self.fallback_url
-        if self.button_type == 'element_share':
-            if self.share_contents:
-                d['share_contents'] = self.share_contents
         return d
 
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -104,58 +104,6 @@ class TestElements:
         }
         assert expected == res.to_dict()
 
-    def test_share_button(self):
-        btn = elements.Button(
-            button_type='web_url',
-            title='Web button',
-            url='http://facebook.com'
-        )
-        element = elements.Element(
-            title='Element',
-            item_url='http://facebook.com',
-            image_url='http://facebook.com/image.jpg',
-            subtitle='Subtitle',
-            buttons=[
-                btn
-            ]
-        )
-        template = GenericTemplate(
-            elements=[element],
-        )
-
-        res = elements.Button(
-            button_type='element_share',
-            share_contents=template.to_dict()
-        )
-        expected = {
-            'type': 'element_share',
-            'share_contents': {
-                'attachment': {
-                    'type': 'template',
-                    'payload': {
-                        'template_type': 'generic',
-                        'sharable': False,
-                        'elements': [
-                            {
-                                'title': 'Element',
-                                'item_url': 'http://facebook.com',
-                                'image_url': 'http://facebook.com/image.jpg',
-                                'subtitle': 'Subtitle',
-                                'buttons': [
-                                    {
-                                        'type': 'web_url',
-                                        'title': 'Web button',
-                                        'url': 'http://facebook.com'
-                                    }
-                                ]
-                            },
-                        ]
-                    }
-                }
-            }
-        }
-        assert expected == res.to_dict()
-
     def test_button_with_title_over_limit(self, caplog):
         with caplog.at_level(logging.WARNING, logger='fbmessenger.elements'):
             res = elements.Button(button_type='web_url',


### PR DESCRIPTION
Facebook has deprecated the share button and is now rejecting messages containing it (so there's no point in backwards compatibility).