### PR TITLE
setup.py fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## Unreleased
+## 6.1.0
 - Remove share button support (deprecated by Facebook)
 - Add icebreakers support 
+- Python 3.9+ support
 
 ## 6.0.0
 - Switch from message to recipient_id as method input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Remove share button support (deprecated by Facebook)
+- Add icebreakers support 
 
 ## 6.0.0
 - Switch from message to recipient_id as method input

--- a/README.md
+++ b/README.md
@@ -435,3 +435,18 @@ menu = PersistentMenu(menu_items=[menu_item_1, menu_item_2])
 messenger_profile = MessengerProfile(persistent_menus=[menu])
 messenger.set_messenger_profile(messenger_profile.to_dict())
 ```
+
+### Ice Breakers
+
+```python
+from fbmessenger.thread_settings import IceBreakers, IceBreakersItem, MessengerProfile
+
+ice_breaker_1 = IceBreakersItem(iquestion='<QUESTION1>', payload'PAYLOAD1')
+ice_breaker_2 = IceBreakersItem(iquestion='<QUESTION2>', payload'PAYLOAD2')
+
+ice_breakers = IceBreakers(question_items=[ice_breaker_1, ice_breaker_2]
+
+messenger_profile = MessengerProfile(ice_breakers=ice_breakers)
+messenger.set_messenger_profile(messenger_profile.to_dict())
+```
+You can then check for this payload in the `postback` method

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -6,7 +6,7 @@ import hmac
 import six
 import requests
 
-__version__ = '6.0.0'
+__version__ = '6.0.1'
 
 logger = logging.getLogger(__name__)
 

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -149,6 +149,19 @@ class MessengerClient(object):
         )
         return r.json()
 
+    def delete_ice_breakers(self, timeout=None):
+        r = self.session.delete(
+            '{graph_url}/me/messenger_profile'.format(graph_url=self.graph_url),
+            params=self.auth_args,
+            json={
+                'fields': [
+                    'ice_breakers'
+                ],
+            },
+            timeout=timeout
+        )
+        return r.json()
+
     def delete_persistent_menu(self, timeout=None):
         r = self.session.delete(
             '{graph_url}/me/messenger_profile'.format(graph_url=self.graph_url),

--- a/fbmessenger/__init__.py
+++ b/fbmessenger/__init__.py
@@ -6,7 +6,7 @@ import hmac
 import six
 import requests
 
-__version__ = '6.0.1'
+__version__ = '6.1.0'
 
 logger = logging.getLogger(__name__)
 

--- a/fbmessenger/thread_settings.py
+++ b/fbmessenger/thread_settings.py
@@ -28,6 +28,30 @@ class GetStartedButton(object):
             }
 
 
+class IceBreakersItem(object):
+    def __init__(self, question, payload):
+        self.question = question
+        self.payload = payload
+
+    def to_dict(self):
+        return {
+            'question': self.question,
+            'payload': self.payload
+        }
+
+
+class IceBreakers(object):
+    def __init__(self, question_items):
+        if len(question_items) > 6:
+            raise ValueError('You cannot have more than 6 ice breakers items.')
+
+        self.question_items = question_items
+
+    def to_dict(self):
+        if self.question_items:
+            return [item.to_dict() for item in self.question_items]
+
+
 class PersistentMenuItem(object):
     ITEM_TYPES = [
         'nested',
@@ -131,10 +155,11 @@ class PersistentMenu(object):
 
 
 class MessengerProfile(object):
-    def __init__(self, greetings=None, get_started=None, persistent_menus=None):
+    def __init__(self, greetings=None, get_started=None, persistent_menus=None, ice_breakers=None):
         self.greetings = greetings
         self.get_started = get_started
         self.persistent_menus = persistent_menus
+        self.ice_breakers = ice_breakers
 
     def to_dict(self):
         res = {}
@@ -149,5 +174,8 @@ class MessengerProfile(object):
         if self.persistent_menus:
             res['persistent_menu'] = [
                 item.to_dict() for item in self.persistent_menus]
+
+        if self.ice_breakers:
+            res['ice_breakers'] = self.ice_breakers.to_dict()
 
         return res

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ test_requirements = [
     'coverage',
     'pytest-cov',
     'pytest-catchlog',
-    'responses'
+    'responses',
+    'mock',
 ]
 
 # Get the version
@@ -78,7 +79,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=['requests>=2.0'],
+    install_requires=[
+        'requests>=2.0',
+        'six',
+    ],
     packages=['fbmessenger'],
     cmdclass={'test': PyTest},
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ short_description='A python library to communicate with the Facebook Messenger A
 
 
 try:
-    with io.open(os.path.join(base_path, 'README.md'), encoding='utf-8') as f:
+    with io.open('README.md', encoding='utf-8') as f:
         long_description = '\n' + f.read()
 except FileNotFoundError:
     long_description = short_description

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -309,6 +309,25 @@ def test_delete_get_started(client, monkeypatch, default_params):
     )
 
 
+def test_delete_ice_breakers(client, monkeypatch, default_params):
+    mock_delete = mock.Mock()
+    mock_delete.return_value.status_code = 200
+    monkeypatch.setattr('requests.Session.delete', mock_delete)
+    client.delete_ice_breakers()
+
+    assert mock_delete.call_count == 1
+    mock_delete.assert_called_with(
+        'https://graph.facebook.com/v{api_version}/me/messenger_profile'.format(api_version=client.api_version),
+        params=default_params,
+        json={
+            'fields': [
+                'ice_breakers',
+            ],
+        },
+        timeout=None
+    )
+
+
 def test_delete_persistent_menu(client, monkeypatch, default_params):
     mock_delete = mock.Mock()
     mock_delete.return_value.status_code = 200

--- a/tests/test_thread_settings.py
+++ b/tests/test_thread_settings.py
@@ -286,6 +286,36 @@ class TestThreadSettings:
         }
         assert expected == profile.to_dict()
 
+    def test_ice_breakers(self):
+        item = thread_settings.IceBreakersItem(
+            question="<QUESTION>",
+            payload="<PAYLOAD>"
+        )
+        res = thread_settings.IceBreakers(question_items=[item] * 2)
+        profile = thread_settings.MessengerProfile(ice_breakers=res)
+        expected = {
+            'ice_breakers': [
+                {
+                    "question": "<QUESTION>",
+                    "payload": "<PAYLOAD>"
+                },                    {
+                    "question": "<QUESTION>",
+                    "payload": "<PAYLOAD>"
+                },
+            ],
+        }
+        assert expected == profile.to_dict()
+
+    def test_ice_breakers_too_many_items(self):
+        item = thread_settings.IceBreakersItem(
+            question="<QUESTION>",
+            payload="<PAYLOAD>"
+        )
+        item_list = [item] * 7
+        with pytest.raises(ValueError) as err:
+            thread_settings.IceBreakers(question_items=item_list)
+        assert str(err.value) == 'You cannot have more than 6 ice breakers items.'
+
     def test_composer_input_disabled(self):
         item = thread_settings.PersistentMenuItem(
             item_type='web_url',


### PR DESCRIPTION
* before this fix package was not installed (because of NameError) - bug introduced in https://github.com/rehabstudio/fbmessenger/pull/71
* fixed install and test dependencies
* also this PR contains https://github.com/rehabstudio/fbmessenger/pull/84
* version updated, because of last released version (2019) doesn't contain python3.9+ fix.

I expect that package on pypi and repository is abandoned, please consider transfering rights on pypi package not to release it under alternative name, thanks!